### PR TITLE
Fix: `WicImagingComponent.LoadAllComponents()`: An item with the same key has already been added

### DIFF
--- a/WicNet/WicImagingComponent.cs
+++ b/WicNet/WicImagingComponent.cs
@@ -56,7 +56,7 @@ namespace WicNet
                             break;
                     }
 
-                    dic.Add(ic.Clsid, ic);
+                    _ = dic.TryAdd(ic.Clsid, ic);
                     component.Dispose();
                 }
             });

--- a/WicNet/WicImagingComponent.cs
+++ b/WicNet/WicImagingComponent.cs
@@ -56,7 +56,10 @@ namespace WicNet
                             break;
                     }
 
-                    _ = dic.TryAdd(ic.Clsid, ic);
+                    if (dic.ContainsKey(ic.Clsid))
+                    {
+                        dic.Add(ic.Clsid, ic);
+                    }
                     component.Dispose();
                 }
             });


### PR DESCRIPTION
On some machines, exception thrown when there are duplicated components, caused by: `Dictionary.Add(...)`

Replace it with `_ = Dictionary.TryAdd(...)` to suspend the error.

Error details: https://github.com/d2phap/ImageGlass/issues/1892

