### PR TITLE
Fix wrong duplicated key check for `WicImagingComponent.LoadAllComponents()`

### DIFF
--- a/WicNet/WicImagingComponent.cs
+++ b/WicNet/WicImagingComponent.cs
@@ -56,7 +56,7 @@ namespace WicNet
                             break;
                     }
 
-                    if (dic.ContainsKey(ic.Clsid))
+                    if (!dic.ContainsKey(ic.Clsid))
                     {
                         dic.Add(ic.Clsid, ic);
                     }


### PR DESCRIPTION
The condition for checking key is wrong from #5:

```diff
- if (dic.ContainsKey(ic.Clsid))
+ if (!dic.ContainsKey(ic.Clsid))
{
    dic.Add(ic.Clsid, ic);
}
```

